### PR TITLE
ファイルコピーコマンド作成した

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -219,6 +219,11 @@ if has('iconv')
   unlet s:enc_jis
 endif
 
+function! FullFilePath(line1, line2)
+    let l:lines = a:line1 == a:line2 ? a:line1 : a:line1 . "," . a:line2
+    return expand("%:p"). " :".l:lines
+endfunction
+command -range -register CopyFilePath let @<reg> = call('FullFilePath', [<line1>, <line2>])
 
 "--------
 "Overwrite for Environment


### PR DESCRIPTION
デフォルトで使うレジスタを指定したい。
引数にレジスタなしだとエラーになる。